### PR TITLE
Increase coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,51 @@ This project is still under development!
 ### You can find this useful if:
 * You are writing a state-based application with a simple Trigger -> Transition logic
 * You can describe the problem you are solving using a basic State Machine diagram.
-* You do _**not**_ require any advanced Statemachine features like composite states or sub-machines / sub regions.
-<br>
+* You do _**not**_ require any advanced Statemachine features like composite states or sub-machines / sub regions.<br>
+
+
 ## Defining a State Machine
 
 _TL;DR - see examples in `statemachine-examples` module._  
 
+Example:
+```
+// Extend StateMachineDefiner
+// Pre define all possible State Machine states
+override fun defineStates(definer: StatesDefiner<LoginState, LoginTrigger>) {
+    definer.apply {
+        setInitial(INITIAL_STATE)
+        simple(EMAIL_INPUT)
+        choice(PASSWORD_INPUT)
+        terminal(LOGIN_COMPLETE)
+        terminal(LOGIN_FAILED)
+    }
+}
+
+// Pre define all possible State Machine transitions, including transition Guards and Actions
+override fun defineTransitions(definer: TransitionsDefiner<LoginState, LoginTrigger>) {
+    definer.apply {
+        add(sourceId = INITIAL_STATE, targetId = EMAIL_INPUT, triggerId = BEGIN_LOGIN_FLOW, guard = Guard.ofPredicate { true })
+        add(sourceId = EMAIL_INPUT, targetId = PASSWORD_INPUT, triggerId = SEND_EMAIL, guard = emailValidatorGuard)
+        add(sourceId = PASSWORD_INPUT, targetId = LOGIN_COMPLETE, triggerId = SEND_PASSWORD, guard = passwordValidatorGuard)
+        add(sourceId = PASSWORD_INPUT, targetId = LOGIN_FAILED, triggerId = SEND_PASSWORD, guard = passwordAttemptsExceededGuard)
+    }
+}
+```
+
+### Key Components
 The State Machine is made up of a few key components:
 * `States` 
 * `Transitions` that specify possible transitions between States and are made up of:
-  * Source and target states. 
-  * `Triggers` - sent to the state machine to possibly transition to the target state.
+  * Source and target state IDs.
+  * `Triggers` - sent to the state machine to possibly transition to the target state, specified by Trigger ID.
   * `Guards` - in charge of allowing (or preventing) transitioning between states.
   * `Actions` - which are run before, during or after transitioning between states.
-* `S` generic type, specifies the ID of a state
+* `S` generic type, specifies the ID of a State
 * `T` generic type, specifies the ID of a Trigger
 
 Each component can be customized to your specific needs.
-
-
+### Create a custom state machine
 First, extend the `StateMachineDefiner<S, T>` class, where `S` and `T` specify the ID types of your custom States and Transitions, respectively.
 <br><br>
 ### `States`
@@ -39,40 +65,39 @@ Add your own state definitions by overriding the `defineStates()` method and inv
 
 Example:
 ```agsl
-    override fun defineStates(statesDefiner: StatesDefiner<S, T>) {
-        statesDefiner.apply {
-            setInitial(INITIAL_STATE)
-            simple(STATE_A)
-            simple(STATE_B)
-            setTerminal(SUCCESS_STATE)
-            setTerminal(FAILURE_STATE)
-        }
+override fun defineStates(statesDefiner: StatesDefiner<S, T>) {
+    statesDefiner.apply {
+        setInitial(INITIAL_STATE)
+        simple(STATE_A)
+        simple(STATE_B)
+        setTerminal(SUCCESS_STATE)
+        setTerminal(FAILURE_STATE)
     }
+}
 ```
 (_Note you must define at least one initial state and one terminal state_)
 
 Add your own transitions to the definition by overriding the  `defineTransitions()` method and invoking `TransitionsDefiner` methods
 ```agsl
-    override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
-                    definer.apply {
-                        add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, positiveGuard, SomeActionToPerformOnTransition)
-                        add(S.STATE_A, S.STATE_B, T.MOVE_TO_B, positiveGuard)
-                    }
-                }
+override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
+    definer.apply {
+        add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, positiveGuard, SomeActionToPerformOnTransition)
+        add(S.STATE_A, S.STATE_B, T.MOVE_TO_B, positiveGuard)
+    }
+}
 ```
 
-<br>
 
 ### `Guards`
 Extends or simply create your own Guards<br>
 Example:
 ```
 class EmailValidatorGuard : Guard<LoginState, LoginTrigger> {
-        override fun allow(transitionContext: TransitionContext<LoginState, LoginTrigger>): Boolean {
-            val email = (transitionContext.trigger as EmailInputTrigger).email
-            return email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\$".toRegex()) && mockExistingEmails.contains(email)
-        }
+    override fun allow(transitionContext: TransitionContext<LoginState, LoginTrigger>): Boolean {
+        val email = (transitionContext.trigger as EmailInputTrigger).email
+        return email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\$".toRegex()) && mockExistingEmails.contains(email)
     }
+}
 ```
 You can also define a simple guard inline, example:
 ```agsl
@@ -92,11 +117,15 @@ TransitionAction.create { log.info("A transition has happened") }
 
 
 ## How to run a state-machine
-* Create `StateMachineDefiner<S, T>` instance is properly defined<br>
-* Get the final `StateMachineDefinition` by calling `getDefinition()`.
-* Construct a `DefaultStateMachineFactory<S, T>` (you can also create your own `StateMachineFactory`) 
-* Create a StateMachine instance by calling the `statemachineFactory.create(<stateMachineId>, <stateMachineDefinition>)` and `start()` it.
-* Trigger the StateMachine with the `Triggers` you defined earlier.
+```agsl
+val definer = CustomStateMachineDefiner()
+val definition = definer.getDefinition()
+val factory = DefaultStateMachineFactory()
+val sm = factory.createStarted(<state machine id>, definition)
+// The State Machine is now running and can be triggered
+```
 
 ## UML - State Machine Visualization
+A Gradle Plugin is available to generate UML visualzations for your defined State machine.
+
 See [statemachine-uml-plugin](./statemachine-uml-plugin/README.md)

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/DefaultStateMachine.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/DefaultStateMachine.kt
@@ -25,8 +25,8 @@ open class DefaultStateMachine<S, T>(
     private var started = false
     private var finished = false
 
-    override val state: State<S, T> get() = context.getState()
-    override val id: String get() = context.getId()
+    override val state: State<S, T> get() = context.state
+    override val id: String get() = context.id
 
     override fun start() {
         assertNotFinished()
@@ -65,7 +65,7 @@ open class DefaultStateMachine<S, T>(
     }
 
     private fun runTriggerFlow(trigger: Trigger<T>?): State<S, T> {
-        return transitionMap.getTransitions(state.id, trigger?.getTriggerId())
+        return transitionMap.getTransitions(state.id, trigger?.id)
             .map { DefaultTransitionContext(context, it, trigger) }
             .firstOrNull { shouldTransition(it) }
             ?.also { log.debug("Guard evaluated to true. transitioning to {}", it.transition.target) }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/DefaultStateMachine.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/DefaultStateMachine.kt
@@ -68,10 +68,10 @@ open class DefaultStateMachine<S, T>(
         return transitionMap.getTransitions(state.id, trigger?.id)
             .map { DefaultTransitionContext(context, it, trigger) }
             .firstOrNull { shouldTransition(it) }
-            ?.also { log.debug("Guard evaluated to true. transitioning to {}", it.transition.target) }
+            ?.also { log.debug("Guard evaluated to true. transitioning to {}", it.transition.targetId) }
             ?.let { transitionContext ->
                 state.exitAction?.act(context)
-                val targetState = statesMap[transitionContext.transition.target]!!
+                val targetState = statesMap[transitionContext.transition.targetId]!!
                 transitionContext.transition.actions.forEach { action -> action.act(transitionContext) }
                 context.transitionToState(targetState)
                 // execute entry action

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/DefaultStateMachineContext.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/DefaultStateMachineContext.kt
@@ -3,25 +3,16 @@ package io.github.yonigev.sfsm.context
 import io.github.yonigev.sfsm.state.State
 
 /** A default [StateMachineContext] implementation, uses a [MutableMap] as a property store. */
-open class DefaultStateMachineContext<S, T>(
-    private var id: String,
-    private var state: State<S, T>,
-    private val properties: MutableMap<Any, Any> = mutableMapOf(),
-) : StateMachineContext<S, T> {
+open class DefaultStateMachineContext<S, T> (
+    override val id: String,
+    override var state: State<S, T>,
+    private val properties: MutableMap<Any, Any> = mutableMapOf()) : StateMachineContext<S, T> {
     override fun transitionToState(state: State<S, T>) {
         this.state = state
     }
 
-    override fun getId(): String {
-        return id
-    }
-
-    override fun getState(): State<S, T> {
-        return state
-    }
-
-    override fun getProperty(key: Any): Any {
-        return properties[key]!!
+    override fun getProperty(key: Any): Any? {
+        return properties[key]
     }
 
     override fun getPropertyOrDefault(key: Any, default: Any): Any {

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/DefaultStateMachineContext.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/DefaultStateMachineContext.kt
@@ -6,7 +6,8 @@ import io.github.yonigev.sfsm.state.State
 open class DefaultStateMachineContext<S, T> (
     override val id: String,
     override var state: State<S, T>,
-    private val properties: MutableMap<Any, Any> = mutableMapOf()) : StateMachineContext<S, T> {
+    private val properties: MutableMap<Any, Any> = mutableMapOf(),
+) : StateMachineContext<S, T> {
     override fun transitionToState(state: State<S, T>) {
         this.state = state
     }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/StateMachineContext.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/context/StateMachineContext.kt
@@ -7,10 +7,10 @@ import io.github.yonigev.sfsm.state.State
  * along with additional properties that define that state.
  */
 sealed interface StateMachineContext<S, T> {
-    fun getId(): String
-    fun getState(): State<S, T>
+    val id: String
+    var state: State<S, T>
     fun transitionToState(state: State<S, T>)
-    fun getProperty(key: Any): Any
+    fun getProperty(key: Any): Any?
     fun getPropertyOrDefault(key: Any, default: Any): Any
     fun setProperty(key: Any, value: Any): Any
 }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/DefinitionValidator.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/DefinitionValidator.kt
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory
 
 open class DefinitionValidator<S, T> {
     private val log = LoggerFactory.getLogger(this.javaClass)
+    private val choiceStateMinOutgoingTransitions = 2
 
     fun validateStates(states: Set<State<S, T>>): Boolean {
         val initialStates = states.filter { State.PseudoStateType.INITIAL == it.type }
@@ -44,7 +45,7 @@ open class DefinitionValidator<S, T> {
         // Validate transition with a CHOICE state source
         for (choiceState in states.filter { it.type == State.PseudoStateType.CHOICE }) {
             val choiceSourceTransitions = transitions.filter { it.sourceId == choiceState.id }
-            if (choiceSourceTransitions.size < 2) {
+            if (choiceSourceTransitions.size < choiceStateMinOutgoingTransitions) {
                 throw StateMachineDefinitionException("Choice state with ${choiceSourceTransitions.size} outgoing transitions")
             }
         }
@@ -55,7 +56,7 @@ open class DefinitionValidator<S, T> {
                 it.sourceId == nonChoiceStateTransition.sourceId &&
                     it.triggerId == nonChoiceStateTransition.triggerId
             }
-            if (similarTransitions.size > 1) {
+            if (similarTransitions.size >= choiceStateMinOutgoingTransitions) {
                 throw StateMachineDefinitionException(
                     "Found multiple transitions with non-choice source state: ${nonChoiceStateTransition.sourceId} " +
                         "and trigger: ${nonChoiceStateTransition.triggerId}",

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefiner.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefiner.kt
@@ -2,6 +2,8 @@ package io.github.yonigev.sfsm.definition
 
 import io.github.yonigev.sfsm.definition.state.StatesDefiner
 import io.github.yonigev.sfsm.definition.transition.TransitionsDefiner
+import io.github.yonigev.sfsm.state.State
+import io.github.yonigev.sfsm.transition.Transition
 import org.slf4j.LoggerFactory
 
 /**
@@ -19,11 +21,14 @@ abstract class StateMachineDefiner<S, T>(private val name: String? = null) {
     protected abstract fun defineTransitions(definer: TransitionsDefiner<S, T> = this.transitionsDefiner)
 
     fun getDefinition(): StateMachineDefinition<S, T> {
-        val states = statesDefiner.getStates().let { it.ifEmpty { defineStates() }; statesDefiner.getStates() }
-        val transitions = transitionsDefiner.getTransitions()
-            .let { it.ifEmpty { defineTransitions() }; transitionsDefiner.getTransitions() }
-        validator.validateStates(states)
-        validator.validateTransitions(states, transitions)
+        val states = defineStates().let { statesDefiner.getStates() }
+        val transitions = defineTransitions().let { transitionsDefiner.getTransitions() }
+        validateDefinition(states, transitions)
         return StateMachineDefinition(this.name ?: this.javaClass.simpleName, states, transitions)
+    }
+
+    private fun validateDefinition(states: Set<State<S, T>>, transition: Set<Transition<S, T>>) {
+        validator.validateStates(states)
+        validator.validateTransitions(states, transition)
     }
 }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/state/StatesDefiner.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/state/StatesDefiner.kt
@@ -4,7 +4,7 @@ import io.github.yonigev.sfsm.action.StateAction
 import io.github.yonigev.sfsm.state.State
 
 /**
- * Used to define [io.github.yonigev.sfsm.StateMachine] states
+ * Used to create and define [io.github.yonigev.sfsm.StateMachine] states
  */
 open class StatesDefiner<S, T> {
     private val states = mutableListOf<State<S, T>>()
@@ -33,7 +33,7 @@ open class StatesDefiner<S, T> {
     }
 
     /**
-     * Adds a simple state of the state machine, with optional entry and exit actions
+     * Adds a choice state of the state machine, with optional entry and exit actions
      * Added separately to allow Java callers to use the shorter method.
      */
     fun choice(stateId: S, entryAction: StateAction<S, T>?, exitAction: StateAction<S, T>?) {

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/transition/TransitionsDefiner.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/definition/transition/TransitionsDefiner.kt
@@ -24,7 +24,7 @@ open class TransitionsDefiner<S, T> {
         targetId: S,
         triggerId: T?,
         guard: Guard<S, T>,
-        transitionTransitionActions: List<TransitionAction<S, T>>,
+        transitionActions: List<TransitionAction<S, T>>,
     ) {
         add(
             Transition.create(
@@ -32,7 +32,7 @@ open class TransitionsDefiner<S, T> {
                 targetId,
                 triggerId,
                 guard,
-                transitionTransitionActions,
+                transitionActions,
             ),
         )
     }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/guard/Guard.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/guard/Guard.kt
@@ -11,9 +11,20 @@ interface Guard<S, T> {
 
     companion object {
         /**
-         * Create a [io.github.yonigev.sfsm.transition.Transition] guard, based on the provided predicate.
+         * Create a [io.github.yonigev.sfsm.transition.Transition] guard, based on the provided predicate and transition context.
          */
-        fun <S, T> ofPredicate(predicate: (TransitionContext<S, T>) -> Boolean): Guard<S, T> {
+        fun <S, T> ofPredicate(predicate: () -> Boolean): Guard<S, T> {
+            return object : Guard<S, T> {
+                override fun allow(transitionContext: TransitionContext<S, T>): Boolean {
+                    return predicate()
+                }
+            }
+        }
+
+        /**
+         * Convenience function to create a [io.github.yonigev.sfsm.transition.Transition] guard, based on the provided predicate.
+         */
+        fun <S, T> ofContextualPredicate(predicate: (TransitionContext<S, T>) -> Boolean): Guard<S, T> {
             return object : Guard<S, T> {
                 override fun allow(transitionContext: TransitionContext<S, T>): Boolean {
                     return predicate(transitionContext)

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/guard/Guard.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/guard/Guard.kt
@@ -13,10 +13,10 @@ interface Guard<S, T> {
         /**
          * Create a [io.github.yonigev.sfsm.transition.Transition] guard, based on the provided predicate.
          */
-        fun <S, T> ofPredicate(predicate: () -> Boolean): Guard<S, T> {
+        fun <S, T> ofPredicate(predicate: (TransitionContext<S, T>) -> Boolean): Guard<S, T> {
             return object : Guard<S, T> {
                 override fun allow(transitionContext: TransitionContext<S, T>): Boolean {
-                    return predicate()
+                    return predicate(transitionContext)
                 }
             }
         }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/state/State.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/state/State.kt
@@ -53,7 +53,7 @@ interface State<S, T> {
                     get() = exitAction
 
                 override fun toString(): String {
-                    return id?.toString() ?: "null"
+                    return id.toString()
                 }
             }
         }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/Transition.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/Transition.kt
@@ -4,32 +4,32 @@ import io.github.yonigev.sfsm.action.TransitionAction
 import io.github.yonigev.sfsm.guard.Guard
 
 /**
- * Defines the conditions required for a [io.github.yonigev.sfsm.StateMachine] to transition from state [source] to state [target]
- * if the machine receives the defined [trigger] (or the trigger is null) - the transition will happen only if the [guard]
+ * Defines the conditions required for a [io.github.yonigev.sfsm.StateMachine] to transition from state [sourceId] to state [targetId]
+ * if the machine receives the defined [triggerId] (or the trigger is null) - the transition will happen only if the [guard]
  * allows it. if it does - the defined [actions] will run.
  */
 interface Transition<S, T> {
-    val source: S
-    val target: S
-    val trigger: T?
+    val sourceId: S
+    val targetId: S
+    val triggerId: T?
     val guard: Guard<S, T>
     val actions: Iterable<TransitionAction<S, T>>
 
     companion object {
         fun <S, T> create(
-            source: S,
-            target: S,
-            trigger: T?,
+            sourceId: S,
+            targetId: S,
+            triggerId: T?,
             guard: Guard<S, T> = Guard.ofPredicate { true },
             transitionActions: List<TransitionAction<S, T>>? = null,
         ): Transition<S, T> {
             return object : Transition<S, T> {
-                override val source: S
-                    get() = source
-                override val target: S
-                    get() = target
-                override val trigger: T?
-                    get() = trigger
+                override val sourceId: S
+                    get() = sourceId
+                override val targetId: S
+                    get() = targetId
+                override val triggerId: T?
+                    get() = triggerId
                 override val guard: Guard<S, T>
                     get() = guard
                 override val actions: List<TransitionAction<S, T>>

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/Transition.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/Transition.kt
@@ -24,6 +24,7 @@ interface Transition<S, T> {
             transitionActions: List<TransitionAction<S, T>>? = null,
         ): Transition<S, T> {
             return object : Transition<S, T> {
+
                 override val sourceId: S
                     get() = sourceId
                 override val targetId: S

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/TransitionMap.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/TransitionMap.kt
@@ -3,7 +3,7 @@ package io.github.yonigev.sfsm.transition
 /**
  * A set of transitions as part of a State Machine's definition for faster access
  */
-class TransitionMap<S, T>(transitions: Set<Transition<S, T>>) {
+class TransitionMap<S, T> (transitions: Set<Transition<S, T>>) {
     private val transitionsMap: Map<Pair<S, T?>, Collection<Transition<S, T>>> = buildTransitionMap(transitions)
 
     fun getTransitions(stateId: S, trigger: T?): Collection<Transition<S, T>> {

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/TransitionMap.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/transition/TransitionMap.kt
@@ -15,7 +15,7 @@ class TransitionMap<S, T> (transitions: Set<Transition<S, T>>) {
     private fun buildTransitionMap(transitions: Set<Transition<S, T>>): Map<Pair<S, T?>, Collection<Transition<S, T>>> {
         val mutableMap = mutableMapOf<Pair<S, T?>, List<Transition<S, T>>>()
         transitions.forEach { t ->
-            val key = Pair(t.source, t.trigger)
+            val key = Pair(t.sourceId, t.triggerId)
             mutableMap.computeIfPresent(key) { k, v -> mutableMap[k].also { (v as MutableList).add(t) } }
             mutableMap.computeIfAbsent(key) { _ -> mutableListOf(t) }
         }

--- a/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/trigger/Trigger.kt
+++ b/statemachine-core/src/main/kotlin/io/github/yonigev/sfsm/trigger/Trigger.kt
@@ -5,13 +5,13 @@ package io.github.yonigev.sfsm.trigger
  * T is the ID type of the trigger
  */
 interface Trigger<T> {
-    fun getTriggerId(): T
+    val id: T
+
     companion object {
-        fun <S, T> ofId(id: T): Trigger<T> {
+        fun <T> ofId(id: T): Trigger<T> {
             return object : Trigger<T> {
-                override fun getTriggerId(): T {
-                    return id
-                }
+                override val id: T
+                    get() = id
             }
         }
     }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/StateMachineTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/StateMachineTest.kt
@@ -7,9 +7,9 @@ import io.github.yonigev.sfsm.definition.state.StatesDefiner
 import io.github.yonigev.sfsm.definition.transition.TransitionsDefiner
 import io.github.yonigev.sfsm.factory.DefaultStateMachineFactory
 import io.github.yonigev.sfsm.guard.Guard
+import io.github.yonigev.sfsm.trigger.Trigger
 import io.github.yonigev.sfsm.util.S
 import io.github.yonigev.sfsm.util.StateMachineTestUtil
-import io.github.yonigev.sfsm.util.StateMachineTestUtil.Companion.createTrigger
 import io.github.yonigev.sfsm.util.T
 import io.github.yonigev.sfsm.util.positiveGuard
 import org.junit.jupiter.api.Test
@@ -26,10 +26,10 @@ class StateMachineTest {
         val sm: StateMachine<S, T> = stateMachineFactory.create("TEST_ID", stateMachineDefiner.getDefinition()).also { it.start() }
         assertEquals(S.INITIAL, sm.state.id)
 
-        sm.trigger(createTrigger(T.MOVE_TO_A)).also { assertEquals(sm.state.id, S.STATE_A) }
-        sm.trigger(createTrigger(T.MOVE_TO_B)).also { assertEquals(sm.state.id, S.STATE_B) }
-        sm.trigger(createTrigger(T.MOVE_TO_C)).also { assertNotEquals(sm.state.id, S.STATE_C) }
-        sm.trigger(createTrigger(T.END)).also { assertEquals(sm.state.id, S.TERMINAL_STATE) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_A)).also { assertEquals(sm.state.id, S.STATE_A) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_B)).also { assertEquals(sm.state.id, S.STATE_B) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_C)).also { assertNotEquals(sm.state.id, S.STATE_C) }
+        sm.trigger(Trigger.ofId(T.END)).also { assertEquals(sm.state.id, S.TERMINAL_STATE) }
     }
 
     @Test
@@ -60,16 +60,16 @@ class StateMachineTest {
         var sm: StateMachine<S, T> = stateMachineFactory.createStarted("SHOULD_STOP_AT_STATE_C", stateMachineDefinition)
             .also { assertEquals(S.INITIAL, it.state.id) }
 
-        sm.trigger(createTrigger(T.MOVE_TO_A)).also { assertEquals(S.STATE_A, sm.state.id) }
-        sm.trigger(createTrigger(T.MOVE_TO_B)).also { assertEquals(S.STATE_B, sm.state.id) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_A)).also { assertEquals(S.STATE_A, sm.state.id) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_B)).also { assertEquals(S.STATE_B, sm.state.id) }
 
-        sm.trigger(createTrigger(T.MOVE_TO_C_OR_END)).also { assertEquals(S.STATE_C, sm.state.id) }
+        sm.trigger(Trigger.ofId(T.MOVE_TO_C_OR_END)).also { assertEquals(S.STATE_C, sm.state.id) }
         sm = stateMachineFactory.createStarted("SHOULD_END", stateMachineDefinition)
         shouldEnd = true
         sm.apply {
-            trigger(createTrigger(T.MOVE_TO_A))
-            trigger(createTrigger(T.MOVE_TO_B))
-            trigger(createTrigger(T.MOVE_TO_C_OR_END))
+            trigger(Trigger.ofId(T.MOVE_TO_A))
+            trigger(Trigger.ofId(T.MOVE_TO_B))
+            trigger(Trigger.ofId(T.MOVE_TO_C_OR_END))
         }.also { assertEquals(S.TERMINAL_STATE, sm.state.id) }
     }
 
@@ -94,7 +94,7 @@ class StateMachineTest {
         val stateMachineDefinition = stateMachineDefiner.getDefinition()
         val sm: StateMachine<S, T> = stateMachineFactory.createStarted("TEST_ID", stateMachineDefinition)
         assertEquals(S.INITIAL, sm.state.id)
-        sm.trigger(createTrigger(T.MOVE_TO_A))
+        sm.trigger(Trigger.ofId(T.MOVE_TO_A))
         assertEquals(S.TERMINAL_STATE, sm.state.id)
     }
 
@@ -131,9 +131,9 @@ class StateMachineTest {
 
         val sm: StateMachine<S, T> = stateMachineFactory.createStarted("TEST_ID", stateMachineDefiner.getDefinition())
             .apply {
-                trigger(createTrigger(T.MOVE_TO_A))
-                trigger(createTrigger(T.MOVE_TO_B))
-                trigger(createTrigger(T.FORCE_MOVE_TO_C))
+                trigger(Trigger.ofId(T.MOVE_TO_A))
+                trigger(Trigger.ofId(T.MOVE_TO_B))
+                trigger(Trigger.ofId(T.FORCE_MOVE_TO_C))
             }
         assertEquals(S.STATE_C, sm.state.id)
         assertEquals(output, listOf(1, 2, 3))
@@ -163,9 +163,9 @@ class StateMachineTest {
                 assertEquals(S.INITIAL, it.state.id)
             }
             .apply {
-                trigger(createTrigger(T.MOVE_TO_A))
-                trigger(createTrigger(T.MOVE_TO_B))
-                trigger(createTrigger(T.END))
+                trigger(Trigger.ofId(T.MOVE_TO_A))
+                trigger(Trigger.ofId(T.MOVE_TO_B))
+                trigger(Trigger.ofId(T.END))
             }
 
         assertEquals(listOf(1, 2, 3, 4, 5, 6, 7, 8), output)

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/StateMachineTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/StateMachineTest.kt
@@ -7,9 +7,12 @@ import io.github.yonigev.sfsm.definition.state.StatesDefiner
 import io.github.yonigev.sfsm.definition.transition.TransitionsDefiner
 import io.github.yonigev.sfsm.factory.DefaultStateMachineFactory
 import io.github.yonigev.sfsm.guard.Guard
+import io.github.yonigev.sfsm.transition.Transition
+import io.github.yonigev.sfsm.transition.TransitionContext
 import io.github.yonigev.sfsm.trigger.Trigger
 import io.github.yonigev.sfsm.util.S
 import io.github.yonigev.sfsm.util.StateMachineTestUtil
+import io.github.yonigev.sfsm.util.StatefulTrigger
 import io.github.yonigev.sfsm.util.T
 import io.github.yonigev.sfsm.util.positiveGuard
 import org.junit.jupiter.api.Test
@@ -23,7 +26,8 @@ class StateMachineTest {
     fun testBasicStateMachineFlow() {
         val stateMachineDefiner = StateMachineTestUtil.basicStateMachineDefiner()
 
-        val sm: StateMachine<S, T> = stateMachineFactory.create("TEST_ID", stateMachineDefiner.getDefinition()).also { it.start() }
+        val sm: StateMachine<S, T> =
+            stateMachineFactory.create("TEST_ID", stateMachineDefiner.getDefinition()).also { it.start() }
         assertEquals(S.INITIAL, sm.state.id)
 
         sm.trigger(Trigger.ofId(T.MOVE_TO_A)).also { assertEquals(sm.state.id, S.STATE_A) }
@@ -99,6 +103,78 @@ class StateMachineTest {
     }
 
     @Test
+    fun testStateMachineTransition_affectedByTrigger() {
+        val statefulTriggerMessage = StatefulTrigger(T.MOVE_TO_A, "This is an example of a trigger's state")
+        val emptyStringStatefulTriggerMessage = StatefulTrigger(T.MOVE_TO_A, "")
+
+        val stateMachineDefiner = object : StateMachineDefiner<S, T>() {
+            override fun defineStates(definer: StatesDefiner<S, T>) {
+                definer.setInitial(S.INITIAL)
+                definer.simple(S.STATE_A)
+                definer.simple(S.STATE_B)
+                definer.terminal(S.TERMINAL_STATE)
+            }
+
+            override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
+                val statefulTriggerGuard = object : Guard<S, T> {
+                    override fun allow(transitionContext: TransitionContext<S, T>): Boolean {
+                        return (transitionContext.trigger as StatefulTrigger).state.isNotBlank()
+                    }
+                }
+
+                definer.add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, statefulTriggerGuard)
+                definer.add(S.STATE_A, S.STATE_B, null, positiveGuard)
+                definer.add(S.STATE_B, S.TERMINAL_STATE, null, positiveGuard)
+            }
+        }
+
+        val stateMachineDefinition = stateMachineDefiner.getDefinition()
+        // assert that transition is allowed based on the trigger's state / payload
+        val sm1 = stateMachineFactory.createStarted("TEST_ID", stateMachineDefinition)
+        val sm2 = stateMachineFactory.createStarted("TEST_ID_2", stateMachineDefinition)
+        assertEquals(S.INITIAL, sm1.state.id)
+        sm1.trigger(statefulTriggerMessage)
+        sm2.trigger(emptyStringStatefulTriggerMessage)
+        assertEquals(S.TERMINAL_STATE, sm1.state.id)
+        assertNotEquals(S.TERMINAL_STATE, sm2.state.id)
+    }
+
+    @Test
+    fun testStateMachineTransition_affectedByStateMachine_context() {
+        // Allow transition only if the state machine's ID matches a certain ID.
+        // this is to ensure the state machine's context is accessed and read properly when a Guard calculates a transition
+        val stateMachineContextGuard = object : Guard<S, T> {
+            override fun allow(transitionContext: TransitionContext<S, T>): Boolean {
+                return transitionContext.stateMachineContext.id == "TEST_ID"
+            }
+        }
+        val stateMachineDefiner = object : StateMachineDefiner<S, T>() {
+            override fun defineStates(definer: StatesDefiner<S, T>) {
+                definer.setInitial(S.INITIAL)
+                definer.simple(S.STATE_A)
+                definer.simple(S.STATE_B)
+                definer.terminal(S.TERMINAL_STATE)
+            }
+
+            override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
+                definer.add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, stateMachineContextGuard)
+                definer.add(S.STATE_A, S.STATE_B, null, positiveGuard)
+                definer.add(S.STATE_B, S.TERMINAL_STATE, null, positiveGuard)
+            }
+        }
+
+        val stateMachineDefinition = stateMachineDefiner.getDefinition()
+        // assert that transition is allowed based on the trigger's state / payload
+        val sm1 = stateMachineFactory.createStarted("TEST_ID", stateMachineDefinition)
+        val sm2 = stateMachineFactory.createStarted("TEST_ID_2", stateMachineDefinition)
+        assertEquals(S.INITIAL, sm1.state.id)
+        sm1.trigger(Trigger.ofId(T.MOVE_TO_A))
+        sm2.trigger(Trigger.ofId(T.MOVE_TO_A))
+        assertEquals(S.TERMINAL_STATE, sm1.state.id)
+        assertNotEquals(S.TERMINAL_STATE, sm2.state.id)
+    }
+
+    @Test
     fun testStateMachine_TransitionActions_RunningSequentially() {
         val output = mutableListOf<Int>()
 
@@ -111,18 +187,30 @@ class StateMachineTest {
                 definer.terminal(S.TERMINAL_STATE)
             }
 
+            // test out all difference methods for Transition creation
             override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
                 definer.add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, positiveGuard)
-                definer.add(S.STATE_A, S.STATE_B, T.MOVE_TO_B, positiveGuard)
                 definer.add(
-                    S.STATE_B,
-                    S.STATE_C,
-                    T.FORCE_MOVE_TO_C,
-                    positiveGuard,
-                    listOf(
+                    sourceId = S.STATE_A,
+                    targetId = S.STATE_B,
+                    triggerId = T.MOVE_TO_B,
+                    guard = positiveGuard,
+                    transitionActions = listOf(
                         create { output.add(1) },
                         create { output.add(2) },
                         create { output.add(3) },
+                    ),
+                )
+                definer.add(
+                    Transition.create(
+                        sourceId = S.STATE_B,
+                        targetId = S.STATE_C,
+                        triggerId = T.FORCE_MOVE_TO_C,
+                        transitionActions = listOf(
+                            create { output.add(1) },
+                            create { output.add(2) },
+                            create { output.add(3) },
+                        ),
                     ),
                 )
                 definer.add(S.STATE_B, S.TERMINAL_STATE, T.END, positiveGuard)
@@ -136,7 +224,7 @@ class StateMachineTest {
                 trigger(Trigger.ofId(T.FORCE_MOVE_TO_C))
             }
         assertEquals(S.STATE_C, sm.state.id)
-        assertEquals(output, listOf(1, 2, 3))
+        assertEquals(listOf(1, 2, 3, 1, 2, 3), output)
     }
 
     @Test
@@ -148,6 +236,7 @@ class StateMachineTest {
                 definer.setInitial(S.INITIAL)
                 definer.simple(S.STATE_A, StateAction.create { output.add(2) }, StateAction.create { output.add(3) })
                 definer.simple(S.STATE_B, StateAction.create { output.add(5) }, StateAction.create { output.add(6) })
+                definer.choice(S.STATE_B, StateAction.create { output.add(5) }, StateAction.create { output.add(6) })
                 definer.terminal(S.TERMINAL_STATE, StateAction.create { output.add(8) })
             }
 
@@ -155,6 +244,7 @@ class StateMachineTest {
                 definer.add(S.INITIAL, S.STATE_A, T.MOVE_TO_A, positiveGuard, create { output.add(1) })
                 definer.add(S.STATE_A, S.STATE_B, T.MOVE_TO_B, positiveGuard, create { output.add(4) })
                 definer.add(S.STATE_B, S.TERMINAL_STATE, T.END, positiveGuard, create { output.add(7) })
+                definer.add(S.STATE_B, S.STATE_A, T.MOVE_TO_A, positiveGuard, create { output.add(7) })
             }
         }
 

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/context/StateMachineDefaultContextTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/context/StateMachineDefaultContextTest.kt
@@ -1,0 +1,37 @@
+package io.github.yonigev.sfsm.context
+
+import io.github.yonigev.sfsm.state.State
+import io.github.yonigev.sfsm.util.S
+import io.github.yonigev.sfsm.util.T
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class StateMachineDefaultContextTest {
+
+    private val id = "TEST_STATE_MACHINE_ID"
+    private val stateId = S.STATE_B
+
+
+    @Test
+    fun testStateMachineContextCreation() {
+        val context = createContext()
+        assertEquals(id, context.id)
+        assertEquals(stateId, context.state.id)
+    }
+
+    @Test
+    fun testStateMachineContextProperties() {
+        val context = createContext()
+        context.setProperty(123, "Property Of 123")
+        context.setProperty("123", "Property Of \"123\"")
+
+        assertEquals(context.getProperty(123), "Property Of 123")
+        assertEquals(context.getProperty("123"), "Property Of \"123\"")
+        assertEquals(context.getPropertyOrDefault(234, "DEFAULT"), "DEFAULT")
+    }
+
+    private fun createContext(): DefaultStateMachineContext<S, T> {
+        return DefaultStateMachineContext(id, State.create(stateId))
+    }
+
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/context/StateMachineDefaultContextTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/context/StateMachineDefaultContextTest.kt
@@ -11,7 +11,6 @@ class StateMachineDefaultContextTest {
     private val id = "TEST_STATE_MACHINE_ID"
     private val stateId = S.STATE_B
 
-
     @Test
     fun testStateMachineContextCreation() {
         val context = createContext()
@@ -33,5 +32,4 @@ class StateMachineDefaultContextTest {
     private fun createContext(): DefaultStateMachineContext<S, T> {
         return DefaultStateMachineContext(id, State.create(stateId))
     }
-
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinerErrorsTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinerErrorsTest.kt
@@ -117,4 +117,20 @@ class StateMachineDefinerErrorsTest {
             definer.getDefinition()
         }
     }
+
+    @Test
+    fun testMissingInitialStateThrowsException() {
+        val definer = object : StateMachineDefiner<S, T>() {
+            override fun defineStates(definer: StatesDefiner<S, T>) {
+                definer.simple(S.STATE_A)
+            }
+
+            override fun defineTransitions(definer: TransitionsDefiner<S, T>) {
+            }
+        }
+
+        assertThrows<StateMachineDefinitionException> {
+            definer.getDefinition()
+        }
+    }
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinerTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinerTest.kt
@@ -3,9 +3,10 @@ package io.github.yonigev.sfsm.definition
 import io.github.yonigev.sfsm.util.StateMachineTestUtil
 import org.junit.jupiter.api.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class StateMachineDefinitionTest {
+class StateMachineDefinerTest {
 
     @Test
     fun testStateMachineDefinitionCreation() {
@@ -14,5 +15,13 @@ class StateMachineDefinitionTest {
         assertContains(definition.name, "StateMachineDefiner")
         assertTrue(definition.states.isNotEmpty())
         assertTrue(definition.transitions.isNotEmpty())
+    }
+
+    @Test
+    fun testStateMachineDefinition_assignsDefinitionName_whenNotExplicitlyDefined() {
+        val testName = "test definer name"
+        val definer = StateMachineTestUtil.basicStateMachineDefiner(testName)
+        val definition = definer.getDefinition()
+        assertEquals(testName, definition.name)
     }
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionTest.kt
@@ -1,0 +1,18 @@
+package io.github.yonigev.sfsm.definition
+
+import io.github.yonigev.sfsm.util.StateMachineTestUtil
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+
+class StateMachineDefinitionTest {
+
+    @Test
+    fun testStateMachineDefinitionCreation() {
+        val definer = StateMachineTestUtil.basicStateMachineDefiner()
+        val definition = definer.getDefinition()
+        assertContains(definition.name, "StateMachineDefiner")
+        assertTrue(definition.states.isNotEmpty())
+        assertTrue(definition.transitions.isNotEmpty())
+    }
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionValidatorTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionValidatorTest.kt
@@ -1,0 +1,120 @@
+package io.github.yonigev.sfsm.definition
+
+import io.github.yonigev.sfsm.state.State
+import io.github.yonigev.sfsm.transition.Transition
+import io.github.yonigev.sfsm.util.S
+import io.github.yonigev.sfsm.util.StateMachineTestUtil
+import io.github.yonigev.sfsm.util.T
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class StateMachineDefinitionValidatorTest {
+    val validator = DefinitionValidator<S, T>()
+
+    @Test
+    fun test_valid() {
+        val definition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        assertTrue(validator.validateStates(definition.states))
+        assertTrue(validator.validateTransitions(definition.states, definition.transitions))
+    }
+
+    @Test
+    fun test_invalidInitialStates() {
+        val definition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        val badStates = (listOf(State.initial<S, T>(S.INITIAL)) + definition.states).toSet()
+
+        val badDefinition = StateMachineDefinition("TEST", badStates, definition.transitions)
+
+        val exception = assertThrows<StateMachineDefinitionException> {
+            validator.validateStates(badDefinition.states)
+        }
+
+        assertNotNull(exception)
+        assertFalse(exception.message.isNullOrBlank())
+        assertContains(exception.message!!, State.PseudoStateType.INITIAL.toString())
+    }
+
+    @Test
+    fun test_invalidEndStates() {
+        val definition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        val badStates = definition.states.filter { it.type != State.PseudoStateType.TERMINAL }.toSet()
+
+        val badDefinition = StateMachineDefinition("TEST", badStates, definition.transitions)
+
+        val exception = assertThrows<StateMachineDefinitionException> {
+            validator.validateStates(badDefinition.states)
+        }
+
+        assertNotNull(exception)
+        assertFalse(exception.message.isNullOrBlank())
+        assertContains(exception.message!!, "END")
+    }
+
+    @Test
+    fun test_missingStates() {
+        val badDefinition = StateMachineDefinition(
+            "TEST",
+            setOf(State.initial(S.INITIAL), State.terminal(S.TERMINAL_STATE)),
+            setOf(
+                Transition.create(S.INITIAL, S.STATE_A, T.MOVE_TO_A),
+                Transition.create(S.STATE_A, S.TERMINAL_STATE, T.END),
+            ),
+        )
+
+        assertThrows<StateMachineDefinitionException> {
+            validator.validateTransitions(badDefinition.states, badDefinition.transitions)
+        }
+    }
+
+    @Test
+    fun test_choiceState_onlyOneTransition() {
+        val badDefinition = StateMachineDefinition(
+            "TEST",
+            setOf(
+                State.initial(S.INITIAL),
+                State.choice(S.STATE_A),
+                State.terminal(S.TERMINAL_STATE),
+            ),
+            setOf(
+                Transition.create(S.INITIAL, S.STATE_A, T.MOVE_TO_A),
+                Transition.create(S.STATE_A, S.TERMINAL_STATE, T.END),
+            ),
+        )
+
+        val exception = assertThrows<StateMachineDefinitionException> {
+            validator.validateTransitions(badDefinition.states, badDefinition.transitions)
+        }
+
+        assertContains(exception.message!!.lowercase(), "choice")
+    }
+
+    @Test
+    fun test_mutipleSimlarTransition_sameSourceState_non_choice() {
+        val badDefinition = StateMachineDefinition(
+            "TEST",
+            setOf(
+                State.initial(S.INITIAL),
+                State.create(S.STATE_A),
+                State.create(S.STATE_B),
+                State.create(S.STATE_C),
+                State.terminal(S.TERMINAL_STATE),
+            ),
+            setOf(
+                Transition.create(S.INITIAL, S.STATE_A, T.MOVE_TO_A),
+                Transition.create(S.STATE_A, S.STATE_B, T.END),
+                Transition.create(S.STATE_A, S.STATE_C, T.END),
+                Transition.create(S.STATE_A, S.TERMINAL_STATE, T.END),
+            ),
+        )
+
+        val exception = assertThrows<StateMachineDefinitionException> {
+            validator.validateTransitions(badDefinition.states, badDefinition.transitions)
+        }
+
+        assertContains(exception.message!!.lowercase(), "choice")
+    }
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionValidatorTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/definition/StateMachineDefinitionValidatorTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class StateMachineDefinitionValidatorTest {
-    val validator = DefinitionValidator<S, T>()
+    private val validator = DefinitionValidator<S, T>()
 
     @Test
     fun test_valid() {

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/exception/StateMachineExceptionHandlingTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/exception/StateMachineExceptionHandlingTest.kt
@@ -16,6 +16,7 @@ import io.github.yonigev.sfsm.util.T
 import io.github.yonigev.sfsm.util.positiveGuard
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.lang.NullPointerException
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
@@ -90,5 +91,28 @@ class StateMachineExceptionHandlingTest {
         sm.trigger(Trigger.ofId(T.END))
         assertEquals(S.TERMINAL_STATE, sm.state.id)
         assertThrows<StateMachineDefinitionException> { sm.start() }
+    }
+
+    @Test
+    fun testStateMachineExceptionCreation_withCausingException() {
+        val definition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        val sm: StateMachine<S, T> = stateMachineFactory.createStarted("TEST_ID", definition)
+        val causingException = NullPointerException("TEST_EXCEPTION_MESSAGE")
+        val exception = StateMachineException(causingException, sm)
+
+        assertEquals(exception.getStateMachineId(), sm.id)
+        assertContains(exception.message, "TEST_EXCEPTION_MESSAGE")
+        assertContains(exception.message, "TEST_ID")
+    }
+
+    @Test
+    fun testStateMachineExceptionCreation_withErrorMessage() {
+        val definition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        val sm: StateMachine<S, T> = stateMachineFactory.createStarted("TEST_ID", definition)
+        val exception = StateMachineException("TEST_EXCEPTION_MESSAGE", sm)
+
+        assertEquals(exception.getStateMachineId(), sm.id)
+        assertContains(exception.message, "TEST_EXCEPTION_MESSAGE")
+        assertContains(exception.message, "TEST_ID")
     }
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/factory/StateMachineFactoryTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/factory/StateMachineFactoryTest.kt
@@ -2,10 +2,13 @@ package io.github.yonigev.sfsm.factory
 
 import io.github.yonigev.sfsm.StateMachine
 import io.github.yonigev.sfsm.definition.StateMachineDefiner
+import io.github.yonigev.sfsm.definition.StateMachineDefinition
+import io.github.yonigev.sfsm.state.State
 import io.github.yonigev.sfsm.util.S
 import io.github.yonigev.sfsm.util.StateMachineTestUtil
 import io.github.yonigev.sfsm.util.T
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class StateMachineFactoryTest {
     @Test
@@ -15,5 +18,21 @@ class StateMachineFactoryTest {
 
         val sm: StateMachine<S, T> = factory.create("TEST_ID", definer.getDefinition()).also { it.start() }
         sm.stop()
+    }
+
+    @Test
+    fun testStateMachineFactory_BadDefinition() {
+        val definer: StateMachineDefiner<S, T> = StateMachineTestUtil.basicStateMachineDefiner()
+        val validDefinition = definer.getDefinition()
+        val badDefinition = StateMachineDefinition(
+            "TEST_ID",
+            validDefinition.states.filter { it.type != State.PseudoStateType.INITIAL }.toSet(),
+            validDefinition.transitions,
+        )
+
+        val factory = DefaultStateMachineFactory<S, T>()
+        assertThrows<NoSuchElementException> {
+            factory.createStarted("TEST_ID", badDefinition)
+        }
     }
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/state/StateCreationTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/state/StateCreationTest.kt
@@ -1,0 +1,48 @@
+package io.github.yonigev.sfsm.state
+
+import io.github.yonigev.sfsm.action.StateAction
+import io.github.yonigev.sfsm.util.S
+import io.github.yonigev.sfsm.util.T
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class StateCreationTest {
+    @Test
+    fun testInitialStateCreation() {
+        val state = State.initial<S, T>(S.STATE_A)
+        assertEquals(state.id, S.STATE_A)
+        assertEquals(State.PseudoStateType.INITIAL, state.type)
+        assertEquals(state.entryAction, null)
+        assertEquals(state.exitAction, null)
+    }
+
+    @Test
+    fun testSimpleStateCreation() {
+        val someAction = StateAction.create<S, T> {}
+        val state = State.create(S.STATE_A, entryAction = someAction, exitAction = someAction)
+        assertEquals(state.id, S.STATE_A)
+        assertEquals(State.PseudoStateType.SIMPLE, state.type)
+        assertEquals(state.entryAction, someAction)
+        assertEquals(state.exitAction, someAction)
+        assertEquals(state.toString(), "STATE_A")
+    }
+
+    @Test
+    fun testChoiceStateCreation() {
+        val state = State.choice<S, T>(S.STATE_A)
+        assertEquals(state.id, S.STATE_A)
+        assertEquals(State.PseudoStateType.CHOICE, state.type)
+        assertEquals(state.entryAction, null)
+        assertEquals(state.exitAction, null)
+    }
+
+    @Test
+    fun testTerminalStateCreation() {
+        val someAction = StateAction.create<S, T> {}
+        val state = State.terminal(S.STATE_A, entryAction = someAction)
+        assertEquals(state.id, S.STATE_A)
+        assertEquals(State.PseudoStateType.TERMINAL, state.type)
+        assertEquals(state.entryAction, someAction)
+        assertEquals(state.exitAction, null)
+    }
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionCreationTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionCreationTest.kt
@@ -1,0 +1,47 @@
+package io.github.yonigev.sfsm.transition
+
+import io.github.yonigev.sfsm.action.TransitionAction
+import io.github.yonigev.sfsm.util.S
+import io.github.yonigev.sfsm.util.T
+import io.github.yonigev.sfsm.util.positiveGuard
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class TransitionCreationTest {
+    @Test
+    fun testTransitionCreation_nullActions() {
+        val transition = Transition.create(
+            S.STATE_A,
+            S.STATE_B,
+            T.MOVE_TO_B,
+            positiveGuard,
+        )
+        assertEquals(S.STATE_A, transition.sourceId)
+        assertEquals(S.STATE_B, transition.targetId)
+        assertEquals(T.MOVE_TO_B, transition.triggerId)
+        assertNotNull(transition.actions)
+        assert(transition.actions.none())
+    }
+
+    @Test
+    fun testTransitionCreation_nonNullActions() {
+        val action1 = TransitionAction.create<S, T> { }
+        val action2 = TransitionAction.create<S, T> { }
+        val transition = Transition.create(
+            S.STATE_A,
+            S.STATE_B,
+            T.MOVE_TO_B,
+            positiveGuard,
+            transitionActions = listOf(action1, action2),
+        )
+        assertEquals(S.STATE_A, transition.sourceId)
+        assertEquals(S.STATE_B, transition.targetId)
+        assertEquals(T.MOVE_TO_B, transition.triggerId)
+        assertNotNull(transition.actions)
+
+        val actionIterator = transition.actions.iterator()
+        assertEquals(action1, actionIterator.next())
+        assertEquals(action2, actionIterator.next())
+    }
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionMapTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionMapTest.kt
@@ -14,16 +14,14 @@ class TransitionMapTest {
         val transitionMap = TransitionMap(transitions)
 
         for (transition in transitions) {
-            val mappedTransitions = transitionMap.getTransitions(transition.source, transition.trigger)
+            val mappedTransitions = transitionMap.getTransitions(transition.sourceId, transition.triggerId)
             assertNotNull(mappedTransitions)
             assertTrue(mappedTransitions.isNotEmpty())
 
             mappedTransitions.forEach {
-                assertEquals(it.source, transition.source)
-                assertEquals(it.trigger, transition.trigger)
+                assertEquals(it.sourceId, transition.sourceId)
+                assertEquals(it.triggerId, transition.triggerId)
             }
         }
     }
-
-
 }

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionMapTest.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/transition/TransitionMapTest.kt
@@ -1,0 +1,29 @@
+package io.github.yonigev.sfsm.transition
+
+import io.github.yonigev.sfsm.util.StateMachineTestUtil
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TransitionMapTest {
+    @Test
+    fun testTransitionMap_containsAllTransitions() {
+        val stateMachineDefinition = StateMachineTestUtil.basicStateMachineDefiner().getDefinition()
+        val transitions = stateMachineDefinition.transitions
+        val transitionMap = TransitionMap(transitions)
+
+        for (transition in transitions) {
+            val mappedTransitions = transitionMap.getTransitions(transition.source, transition.trigger)
+            assertNotNull(mappedTransitions)
+            assertTrue(mappedTransitions.isNotEmpty())
+
+            mappedTransitions.forEach {
+                assertEquals(it.source, transition.source)
+                assertEquals(it.trigger, transition.trigger)
+            }
+        }
+    }
+
+
+}

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
@@ -14,8 +14,8 @@ val negativeGuard = ofPredicate<S, T> { false }
  */
 class StateMachineTestUtil {
     companion object {
-        fun basicStateMachineDefiner(): StateMachineDefiner<S, T> {
-            val definer = object : StateMachineDefiner<S, T>() {
+        fun basicStateMachineDefiner(name: String? = null): StateMachineDefiner<S, T> {
+            val definer = object : StateMachineDefiner<S, T>(name) {
                 override fun defineStates(definer: StatesDefiner<S, T>) {
                     definer.setInitial(S.INITIAL)
                     definer.simple(S.STATE_A)

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
@@ -4,6 +4,7 @@ import io.github.yonigev.sfsm.definition.StateMachineDefiner
 import io.github.yonigev.sfsm.definition.state.StatesDefiner
 import io.github.yonigev.sfsm.definition.transition.TransitionsDefiner
 import io.github.yonigev.sfsm.guard.Guard.Companion.ofPredicate
+import io.github.yonigev.sfsm.trigger.Trigger
 
 val positiveGuard = ofPredicate<S, T> { true }
 val negativeGuard = ofPredicate<S, T> { false }
@@ -35,6 +36,8 @@ class StateMachineTestUtil {
         }
     }
 }
+
+class StatefulTrigger(override val id: T, val state: String) : Trigger<T>
 
 enum class S {
     INITIAL, STATE_A, STATE_B, STATE_C, TERMINAL_STATE

--- a/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
+++ b/statemachine-core/src/test/kotlin/io/github/yonigev/sfsm/util/StateMachineTestUtil.kt
@@ -4,7 +4,6 @@ import io.github.yonigev.sfsm.definition.StateMachineDefiner
 import io.github.yonigev.sfsm.definition.state.StatesDefiner
 import io.github.yonigev.sfsm.definition.transition.TransitionsDefiner
 import io.github.yonigev.sfsm.guard.Guard.Companion.ofPredicate
-import io.github.yonigev.sfsm.trigger.Trigger
 
 val positiveGuard = ofPredicate<S, T> { true }
 val negativeGuard = ofPredicate<S, T> { false }
@@ -33,14 +32,6 @@ class StateMachineTestUtil {
                 }
             }
             return definer
-        }
-
-        fun createTrigger(t: T): Trigger<T> {
-            return object : Trigger<T> {
-                override fun getTriggerId(): T {
-                    return t
-                }
-            }
         }
     }
 }

--- a/statemachine-examples/flight/src/main/java/io/github/yonigev/sfsm/demo/flight/trigger/PassengerUpdateTrigger.java
+++ b/statemachine-examples/flight/src/main/java/io/github/yonigev/sfsm/demo/flight/trigger/PassengerUpdateTrigger.java
@@ -10,7 +10,7 @@ public class PassengerUpdateTrigger implements Trigger<FlightStateMachineDefiner
     }
 
     @Override
-    public FlightStateMachineDefiner.FlightTrigger getTriggerId() {
+    public FlightStateMachineDefiner.FlightTrigger getId() {
         return FlightStateMachineDefiner.FlightTrigger.PASSENGERS_BOARDED;
     }
 

--- a/statemachine-examples/flight/src/main/java/io/github/yonigev/sfsm/demo/flight/trigger/PlaneLocationUpdate.java
+++ b/statemachine-examples/flight/src/main/java/io/github/yonigev/sfsm/demo/flight/trigger/PlaneLocationUpdate.java
@@ -16,7 +16,7 @@ public class PlaneLocationUpdate implements Trigger<FlightTrigger> {
     }
 
     @Override
-    public FlightTrigger getTriggerId() {
+    public FlightTrigger getId() {
         return triggerId;
     }
 }

--- a/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/LoginStateMachineApplication.kt
+++ b/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/LoginStateMachineApplication.kt
@@ -13,7 +13,7 @@ fun main() {
 
     // Begin flow
     sm.trigger(
-        Trigger.ofId<LoginStateMachineDefiner.LoginState, LoginStateMachineDefiner.LoginTrigger>(
+        Trigger.ofId(
             LoginStateMachineDefiner.LoginTrigger.BEGIN_LOGIN_FLOW
         )
     )

--- a/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/trigger/EmailInputTrigger.kt
+++ b/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/trigger/EmailInputTrigger.kt
@@ -3,9 +3,5 @@ package io.github.yonigev.sfsm.demo.userlogin.trigger
 import io.github.yonigev.sfsm.demo.userlogin.LoginStateMachineDefiner.LoginTrigger
 import io.github.yonigev.sfsm.trigger.Trigger
 
-class EmailInputTrigger(val email: String) : Trigger<LoginTrigger> {
-    private val triggerId = LoginTrigger.SEND_EMAIL
-    override fun getTriggerId(): LoginTrigger {
-        return triggerId
-    }
-}
+class EmailInputTrigger(val email: String,
+                        override val id: LoginTrigger = LoginTrigger.SEND_EMAIL) : Trigger<LoginTrigger>

--- a/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/trigger/PasswordInputTrigger.kt
+++ b/statemachine-examples/login/src/main/kotlin/io/github/yonigev/sfsm/demo/userlogin/trigger/PasswordInputTrigger.kt
@@ -3,9 +3,5 @@ package io.github.yonigev.sfsm.demo.userlogin.trigger
 import io.github.yonigev.sfsm.demo.userlogin.LoginStateMachineDefiner.LoginTrigger
 import io.github.yonigev.sfsm.trigger.Trigger
 
-class PasswordInputTrigger(val password: String) : Trigger<LoginTrigger> {
-    private val triggerId = LoginTrigger.SEND_PASSWORD
-    override fun getTriggerId(): LoginTrigger {
-        return triggerId
-    }
-}
+class PasswordInputTrigger(val password: String,
+                           override val id: LoginTrigger =  LoginTrigger.SEND_PASSWORD) : Trigger<LoginTrigger>

--- a/statemachine-examples/login/src/test/kotlin/io/github/yonigev/sfsm/demo/userlogin/LoginStateMachineTest.kt
+++ b/statemachine-examples/login/src/test/kotlin/io/github/yonigev/sfsm/demo/userlogin/LoginStateMachineTest.kt
@@ -16,7 +16,7 @@ class LoginStateMachineTest {
         val factory: DefaultStateMachineFactory<LoginState, LoginTrigger> = DefaultStateMachineFactory()
         factory.createStarted("TEST_SM", stateMachineDefiner.getDefinition()).apply {
             // Begin flow
-            trigger(Trigger.ofId<LoginState, LoginTrigger>(LoginTrigger.BEGIN_LOGIN_FLOW))
+            trigger(Trigger.ofId(LoginTrigger.BEGIN_LOGIN_FLOW))
             assertEquals(LoginState.EMAIL_INPUT, state.id)
             // Enter email
             trigger(EmailInputTrigger("somebody2@email.com"))
@@ -37,7 +37,7 @@ class LoginStateMachineTest {
         val factory: DefaultStateMachineFactory<LoginState, LoginTrigger> = DefaultStateMachineFactory()
         factory.createStarted("TEST_SM", stateMachineDefiner.getDefinition()).apply {
             // Begin flow
-            trigger(Trigger.ofId<LoginState, LoginTrigger>(LoginTrigger.BEGIN_LOGIN_FLOW))
+            trigger(Trigger.ofId(LoginTrigger.BEGIN_LOGIN_FLOW))
             assertEquals(LoginState.EMAIL_INPUT, state.id)
             // Enter email
             trigger(EmailInputTrigger("somebody2@email.com"))

--- a/statemachine-uml-plugin/src/main/kotlin/io/github/yonigev/sfsm/uml/UmlMapper.kt
+++ b/statemachine-uml-plugin/src/main/kotlin/io/github/yonigev/sfsm/uml/UmlMapper.kt
@@ -31,5 +31,5 @@ private fun mapState(state: State<*, *>): String {
 }
 
 private fun mapTransition(transition: Transition<*, *>): String {
-    return "${transition.source} -> ${transition.target} [label=\"${transition.trigger}\"];"
+    return "${transition.sourceId} -> ${transition.targetId} [label=\"${transition.triggerId}\"];"
 }

--- a/statemachine-uml-plugin/src/test/kotlin/io/github/yonigev/sfsm/uml/UmlMapperTest.kt
+++ b/statemachine-uml-plugin/src/test/kotlin/io/github/yonigev/sfsm/uml/UmlMapperTest.kt
@@ -10,6 +10,6 @@ class UmlMapperTest {
         assert(umlString.isNotBlank())
         assert(umlString.contains(smDefinition.name))
         smDefinition.states.forEach { assert(umlString.contains(it.toString())) }
-        smDefinition.transitions.forEach { assert(umlString.contains(it.trigger.toString())) }
+        smDefinition.transitions.forEach { assert(umlString.contains(it.triggerId.toString())) }
     }
 }


### PR DESCRIPTION
## Description
* Changed the `StateMachineContext` interface to define `id` and `state` fields, instead of getters
* Changed a Trigger's `triggerId` getter to be `id` field
* Referring to `stateId` instead of `state` wherever relevant
* Changed a Transition's source, target and trigger as `sourceId`, `targetId` and `triggerId`
* Added the `Guard.ofContextualPredicate` convenience function to allow the creation of Guard that require the transition's context to allow transitions
* Increased test coverage to 100%